### PR TITLE
최대 너비를 제한한다

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,3 +2,10 @@
   margin: 0;
   padding: 0;
 }
+
+.App {
+  max-width: 500px;
+  height: 100vh;
+  margin: auto;
+  box-shadow: 0 0 10px 2px gray;
+}


### PR DESCRIPTION
최대 너비 500px로 제한
그림자를 통해 경계선 구분
margin: auto를 통한 중앙 정렬

![스크린샷 2021-05-14 오후 6 56 03](https://user-images.githubusercontent.com/45786387/118254419-0a1bbd80-b4e6-11eb-810e-8b13871af8ec.png)

조금 크긴 한데,
전체적으로 모바일처럼 세로로 길게 해서 배치 차이를 좀 없앨 수 있길 기대함

close #8 
