### PR TITLE
임시 가게 데이터셋을 추가한다

### DIFF
--- a/src/data/places.js
+++ b/src/data/places.js
@@ -1,0 +1,58 @@
+const places = [
+  {
+    name: "진땡이 순대국",
+    category: "한식",
+    phone: "02-2263-8441",
+    address: "서울 중구 필동로 15-9",
+    location: {
+      latitude: 37.56019,
+      longitude: 126.99655,
+    },
+    comment: "허기진 배를 가득 채워줄 든든한 국밥, 동국인의 해장 no.1",
+    menu: "순대국",
+    price: 7_000,
+    score: 4.21,
+    photo:
+      "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=http%3A%2F%2Fblogfiles.naver.net%2FMjAyMTA0MDZfMTEw%2FMDAxNjE3Njg1NDMzMTMy.2rH8Y8I1rPJSH5OeDorZp_2wFrnXHlIWkxW2kwuwYegg.q1cEDFSctQ7JqOqkZjnrrSNI7mQuFCLHQ54zQ13MDjwg.JPEG.slangword%2F20210402%25A3%25DF114758.jpg",
+    naver: "http://naver.me/Gw5QaB06",
+    kakao: "https://place.map.kakao.com/14519636",
+  },
+  {
+    name: "동대닭한마리",
+    category: "한식",
+    phone: "02-2269-5596",
+    address: "서울 중구 서애로 16-5",
+    location: {
+      latitude: 37.56102,
+      longitude: 126.99737,
+    },
+    comment: "마음의 고향 빨간 간판집",
+    menu: "닭한마리(2 ~ 3인)",
+    price: 22_000,
+    score: 4.46,
+    photo:
+      "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fmyplace-phinf.pstatic.net%2F20201231_300%2F16094242382180rEh3_JPEG%2Fupload_552356f4598ebf3d712478b9dc14df00.jpeg",
+    naver: "http://naver.me/54VLHbnS",
+    kakao: "https://place.map.kakao.com/25085251",
+  },
+  {
+    name: "산타돈부리",
+    category: "일식",
+    phone: "0507-1348-8151",
+    address: "서울 중구 서애로 19",
+    location: {
+      latitude: 37.56072,
+      longitude: 126.99753,
+    },
+    comment: "점심시간 핫플레이스, 사케동도 일품이지만 모든 메뉴가 탁월",
+    menu: "사케동",
+    price: 10_500,
+    score: 4.36,
+    photo:
+      "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=http%3A%2F%2Fblogfiles.naver.net%2FMjAyMDA3MjRfMTA1%2FMDAxNTk1NTg0OTc3NDEx.MhMsQcWdCtPBR026z_zPqrLmbPX4x2m7qbal3XJ2BA0g.wsuL8VTvpa9wwCvN-iNhxgZ3-8esOT3Jhes_dawNsaIg.JPEG.wfejio1%2FIMG_4755.jpg",
+    naver: "http://naver.me/xH2abpNz",
+    kakao: "",
+  },
+];
+
+export default places;


### PR DESCRIPTION
close #18 

제 멋대로 진땡이, 닭한마리, 산타돈부리 추가했습니다.

오늘 내일 안에 가게 정보 표시하는 모달창 구현하도록 하고,
추가적인 데이터셋은 노션 등에 정리 후 한번에 같이 올리도록 하죠.
일단 개발에 차질 없도록 3개정도만 넣는 걸로 하고요.