### PR TITLE
모바일 화면에서 상태표시줄을 전체 높이에서 제외한다.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import SlidingMenu from "./components/SlidingMenu";
 
 const Container = styled.div`
   max-width: 500px;
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
   margin: auto;
   box-shadow: 0 0 10px 2px gray;
   overflow-y: auto;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,16 @@ import "./index.css";
 import App from "./App";
 import { BrowserRouter } from "react-router-dom";
 
+(() => {
+  const setFullHeightProperty = () => {
+    const vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty("--vh", `${vh}px`);
+  };
+
+  setFullHeightProperty();
+  window.addEventListener("resize", setFullHeightProperty);
+})();
+
 ReactDOM.render(
   <BrowserRouter basename={"/dongguk-bob"}>
     <App />


### PR DESCRIPTION
close #34 

<img width="525" alt="스크린샷 2021-06-02 오후 1 35 42" src="https://user-images.githubusercontent.com/45786387/120424499-71bb7f00-c3a7-11eb-8369-212427f69981.png">
이제 스크롤 더 안내려가요